### PR TITLE
Fix sphinx generation warnings

### DIFF
--- a/phdi/azure.py
+++ b/phdi/azure.py
@@ -31,7 +31,7 @@ class AzureFhirServerCredentialManager:
         Otherwise, request a new one.
 
         :param token_reuse_tolerance: Number of seconds before expiration; it
-        is okay to reuse the currently assigned token
+            is okay to reuse the currently assigned token
         """
         if not self._need_new_token(token_reuse_tolerance):
             return self.access_token
@@ -150,15 +150,15 @@ def store_message_and_response(
 
         :param container_url: The url at which to access the container
         :param prefix: The "filepath" prefix used to navigate the
-        virtual directories to the output container
+            virtual directories to the output container
         :param bundle_type: The type of data being written
         :param message_filename: The file name to use to store the message
-        in blob storage
+            in blob storage
         :param response_filename: The file name to use to store the response content
-        in blob storage
+            in blob storage
         :param message: The content of a message encoded as a string.
         :param response: HTTP response information from a transaction related to the
-        `message`.
+            `message`.
     """
     try:
         # First attempt is storing the message directly in the

--- a/phdi/fhir/__init__.py
+++ b/phdi/fhir/__init__.py
@@ -97,7 +97,7 @@ def export_from_fhir_server(
     before shutting down the request.
 
     :param cred_manager: Service used to get an access token used to make a
-    request.
+        request.
     :param fhir_url: FHIR Server base URL
     :param export_scope: Either `Patient` or `Group/[id]` as specified in the FHIR
         spec
@@ -177,9 +177,9 @@ def _compose_export_url(
     :param fhir_url: The url of the FHIR server to export from
     :param export_scope: The data we want back (e.g. Patients)
     :param since: We'll get all FHIR resources that have been updated
-    since this given timestamp
+        since this given timestamp
     :param resource_type: Comma-delimited list of resource types we want
-    back
+        back
     :param container: The container where we want to store the uploaded
     files
     """
@@ -259,7 +259,7 @@ def export_from_fhir_server_poll(
 
     :param poll_url: URL to poll for export information
     :param cred_manager: Service used to get an access token used to make a
-    request.
+        request.
     :param poll_step: the number of seconds to wait between poll requests, waiting
         for export files to be generated. defaults to 30
     :param poll_timeout: the maximum number of seconds to wait for export files to
@@ -332,7 +332,7 @@ def fhir_server_get(
 
     :param url: URL specifying a GET request on a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
-    request.
+        request.
     """
     access_token = cred_manager.get_access_token().token
     # Open connection to the export operation and kickoff process

--- a/phdi/fhir/geospatial/smarty.py
+++ b/phdi/fhir/geospatial/smarty.py
@@ -24,6 +24,7 @@ class SmartyFhirGeocodeClient(FhirGeocodeClient):
         This property:
           1. defines a private instance variable __client
           2. makes it accessible through the use of .client()
+
         This property holds an instance of the base SmartyGeocodeClient,
         which allows the FHIR wrapper to access a SmartyStreets-
         specific connection client without instantiating its own

--- a/phdi/geo.py
+++ b/phdi/geo.py
@@ -38,7 +38,7 @@ def get_geocoder_result(
 
     :param address: The address to perform a geocoding lookup for
     :param client: the SmartyStreets API Client suitable for use with street addresses
-    in the US
+        in the US
     """
 
     lookup = Lookup(street=address)

--- a/phdi/geospatial/__init__.py
+++ b/phdi/geospatial/__init__.py
@@ -56,7 +56,7 @@ class GeocodeClient(ABC):
             state: state to geocode
             postal_code: the postal code to use
             urbanization: urbanization code for area, sector, or regional
-              development (only used for Puerto Rican addresses)
+            development (only used for Puerto Rican addresses)
 
         There is no minimum number of fields that must be specified to use this
         function; however, a minimum of street, city, and state are suggested

--- a/phdi/geospatial/smarty.py
+++ b/phdi/geospatial/smarty.py
@@ -30,6 +30,7 @@ class SmartyGeocodeClient(GeocodeClient):
         This property:
           1. defines a private instance variable __client
           2. makes it accessible through the use of .client()
+
         This property holds a SmartyStreets-specific connection client
         allows a user to geocode without directly referencing the
         underlying vendor service client.

--- a/phdi/schemas.py
+++ b/phdi/schemas.py
@@ -121,7 +121,7 @@ def make_table(
     :param output_format: A string indicating the file format to be used.
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
-    request.
+        request.
     """
     output_path.mkdir(parents=True, exist_ok=True)
     for resource_type in schema:
@@ -183,11 +183,11 @@ def make_schema_tables(
 
     :param schema_path: A path to the location of a YAML schema config file.
     :param base_output_path: A path to the directory where tables of the schema should
-    be written.
+        be written.
     :param output_format: Specifies the file format of the tables to be generated.
     :param fhir_url: URL to a FHIR server.
     :param cred_manager: Service used to get an access token used to make a
-    request.
+        request.
     """
 
     schema = load_schema(schema_path)
@@ -207,13 +207,13 @@ def write_schema_table(
     Write data extracted from the FHIR Server to a file.
 
     :param data: A list of dictionaries specifying the data for each row of a table
-    where the keys of each dict correspond to the columns, and the values contain the
-    data for each entry in a row.
+        where the keys of each dict correspond to the columns, and the values contain
+        the data for each entry in a row.
     :param output_file_name: Full name for the file where the table is to be written.
     :param output_format: Specifies the file format of the table to be written.
     :param writer: A writer object that can be kept open between calls of this function
-    to support file formats that cannot be appended to after being written
-    (e.g. parquet).
+        to support file formats that cannot be appended to after being written
+        (e.g. parquet).
     """
 
     if file_format == "parquet":
@@ -243,7 +243,7 @@ def print_schema_summary(
 
     :param schema_directory: Path specifying location of schema tables.
     :param display_head: Print the head of each table when true. Note depending on the
-    file format this may require reading large amounts of data into memory.
+        file format this may require reading large amounts of data into memory.
     """
     for (directory_path, _, file_names) in os.walk(schema_directory):
         for file_name in file_names:

--- a/phdi/standardize.py
+++ b/phdi/standardize.py
@@ -26,7 +26,7 @@ def standardize_patient_names(
     :param: case: Specifies the casing that should be used for the name.
     :param: remove_numbers: Indicates if numbers should be removed from the name.
     :param overwrite: Indicates whether the original data should be overwritten with
-    the transformed values.
+        the transformed values.
     """
     # Copy the data if we don't want to overwrite the original
     if not overwrite:

--- a/phdi/utils.py
+++ b/phdi/utils.py
@@ -70,7 +70,7 @@ def standardize_text(raw_text: str, **kwargs) -> str:
     Perform standardization on a provided text string, given a set of transformations.
 
     :param raw_text: The raw text string to standardize
-    :param \*\*kwargs: A series of transformations that should be applied to the text
+    :param ``**kwargs``: A series of transformations that should be applied to the text
         string. Only recognized transformations will be utilized; all other specified
         transformations will be ignore. The recognized transformations are as follows:
         - trim (Bool): Indicates if leading and trailing whitespace should be removed.

--- a/phdi/utils.py
+++ b/phdi/utils.py
@@ -70,9 +70,9 @@ def standardize_text(raw_text: str, **kwargs) -> str:
     Perform standardization on a provided text string, given a set of transformations.
 
     :param raw_text: The raw text string to standardize
-    :param **kwargs: A series of transformations that should be applied to the text
-    string. Only recognized transformations will be utilized; all other specified
-    transformations will be ignore. The recognized transformations are as follows:
+    :param \*\*kwargs: A series of transformations that should be applied to the text
+        string. Only recognized transformations will be utilized; all other specified
+        transformations will be ignore. The recognized transformations are as follows:
         - trim (Bool): Indicates if leading and trailing whitespace should be removed.
         - case (Literal["upper", "lower", "title"]): Defines what casing should be
         applied to the string.


### PR DESCRIPTION
There were two types of errors in our sphinx docstrings that have been corrected by this PR:
* If param documentation becomes multiline the 2nd through n-th lines must be indented (4 or 8+ characters)
* When documenting kwargs, asterisks must be escaped so they are not interpreted as formatting (bold)